### PR TITLE
Add jq installatio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,17 @@ RUN export TZ=Europe/Paris && \
 RUN apt-get -y install awscli=1.22.34-1
 
 # Azure
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN mkdir -p /etc/apt/keyrings
 
-# RUN mkdir -p /etc/apt/keyrings && \
-#     curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
-#     gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg && \
-#     chmod go+r /etc/apt/keyrings/microsoft.gpg
+RUN curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
+    gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
 
-# RUN apt-get update && apt-get install azure-cli=2.58.0-1-$(lsb_release -cs)
+RUN chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | \
+    tee /etc/apt/sources.list.d/azure-cli.list
+
+RUN apt-get update && apt-get install azure-cli=2.59.0-1~$(lsb_release -cs)
 
 # GCP
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ WORKDIR /cloud_report
 
 RUN apt-get update
 
-RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv jq
+RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv jq unzip
 
 RUN apt-get -y install hcloud-cli=1.13.0-2build2
 
-# first answer https://unix.stackexchange.com/questions/433942/how-to-specify-extra-tz-info-for-apt-get-install-y-awscli
-RUN export TZ=Europe/Paris && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get -y install awscli=1.22.34-1
+# AWS
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.11.26.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip && rm awscliv2.zip && ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
 
 # Azure
 RUN mkdir -p /etc/apt/keyrings
@@ -37,7 +35,7 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
 RUN apt-get update && apt-get -y install google-cloud-cli=470.0.0-0
 
 # OCI
-
-RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.39.1/scripts/install/install.sh)" -- --accept-all-defaults
+RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.39.1/scripts/install/install.sh)" \
+    -- --accept-all-defaults --oci-cli-version 3.39.1
 
 RUN pip install hdns_cli==1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ RUN apt-get update && apt-get -y install google-cloud-cli=470.0.0-0
 
 # OCI
 
-RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.28.2/scripts/install/install.sh)" -- --accept-all-defaults
+RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.39.1/scripts/install/install.sh)" -- --accept-all-defaults
 
 RUN pip install hdns_cli==1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,15 @@ RUN export TZ=Europe/Paris && \
 
 RUN apt-get -y install awscli
 
+# Azure
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# RUN mkdir -p /etc/apt/keyrings && \
+#     curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
+#     gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg && \
+#     chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+# RUN apt-get update && apt-get install azure-cli=2.58.0-1-$(lsb_release -cs)
 
 # GCP
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
@@ -23,10 +31,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
     apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-RUN apt-get update && apt-get -y install google-cloud-cli
+RUN apt-get update && apt-get -y install google-cloud-cli=470.0.0-0
 
 # OCI
 
-RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- --accept-all-defaults
+RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.28.2/scripts/install/install.sh)" -- --accept-all-defaults
 
-RUN pip install hdns_cli
+RUN pip install hdns_cli==1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ RUN apt-get update
 
 RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv jq
 
-RUN apt-get -y install hcloud-cli
+RUN apt-get -y install hcloud-cli=1.13.0-2build2
 
 # first answer https://unix.stackexchange.com/questions/433942/how-to-specify-extra-tz-info-for-apt-get-install-y-awscli
 RUN export TZ=Europe/Paris && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt-get -y install awscli
+RUN apt-get -y install awscli=1.22.34-1
 
 # Azure
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /cloud_report
 
 RUN apt-get update
 
-RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv
+RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv jq
 
 RUN apt-get -y install hcloud-cli
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Cloud providers' CLI versions:
+
+* GCP - 470.0.0
+* Hetzner - 1.42.0
+* Hetzner DNS - 1.0.0
+* AWS - 2.11.26
+* Azure - 2.59.0
+* OCI - 3.39.1


### PR DESCRIPTION
add required package (`jq`) to list genesis resources using our cloud usage script + cap versions of the cloud providers' CLIs