### PR TITLE
Chore/htz cli update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,3 @@ RUN apt-get update && apt-get -y install google-cloud-cli=470.0.0-0
 # OCI
 RUN bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/v3.39.1/scripts/install/install.sh)" \
     -- --accept-all-defaults --oci-cli-version 3.39.1
-
-RUN pip install hdns_cli==1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update
 
 RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg python3-pip python3-venv jq unzip
 
-RUN apt-get -y install hcloud-cli=1.13.0-2build2
+RUN curl -L "https://github.com/hetznercloud/cli/releases/download/v1.61.0/hcloud-linux-amd64.tar.gz" -o "hcloud.tar.gz"
+RUN tar -xzf hcloud.tar.gz && rm hcloud.tar.gz  && mv hcloud /usr/local/bin/ && sudo chmod +x /usr/local/bin/hcloud
 
 # AWS
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.11.26.zip" -o "awscliv2.zip"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This image is also used in our cloud usage report cronjob.
 ### Cloud providers' CLI versions:
 
 * GCP - 470.0.0
-* Hetzner - 1.42.0
-* Hetzner DNS - 1.0.0
+* Hetzner - 1.61.0
 * AWS - 2.11.26
 * Azure - 2.59.0
 * OCI - 3.39.1


### PR DESCRIPTION
-  added new hcloud cli (include zone parameter)
- removed unsupported hdns_cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hetzner CLI to version 1.61.0
  * Modified setup process for command-line tool installation
  * Removed unused dependency packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->